### PR TITLE
Add verilator target with compatible files

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -5,20 +5,24 @@ package:
 
 sources:
   # Files in this package are meant for simulation only.
+  # Verilator does not support features commonly used in simulation (eg: rand conditioning)
+  - target: any(simulation, verilator)
+    files:
+    - src/clk_rst_gen.sv
+    - src/sim_timeout.sv
+    - src/stream_watchdog.sv
+    - src/signal_highlighter.sv
+
   - target: simulation
     files:
     # Source files grouped in levels. Files in level 0 have no dependencies on files in this
     # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
     # levels 1 and 0, etc. Files within a level are ordered alphabetically.
     # Level 0
-    - src/clk_rst_gen.sv
     - src/rand_id_queue.sv
     - src/rand_stream_mst.sv
     - src/rand_synch_holdable_driver.sv
     - src/rand_verif_pkg.sv
-    - src/signal_highlighter.sv
-    - src/sim_timeout.sv
-    - src/stream_watchdog.sv
     # Level 1
     - src/rand_synch_driver.sv
     # Level 2


### PR DESCRIPTION
Verilator does not yet support all language constructs. This is particularly a problem for files in the 'simulation' target (not just in this repo but also in other repos like axi or apb), one example is constraints on randoms.

This adds all compatible files to the verilator target so they can be used without the problems from the simulation target.